### PR TITLE
`conda env create -f environment.yml` failed for me.

### DIFF
--- a/tools/setup_personal_dl_box.md
+++ b/tools/setup_personal_dl_box.md
@@ -21,14 +21,19 @@ git clone https://github.com/fastai/fastai.git
 cd fastai/ 
 ```
 
+## Step 4: Install header files to build python extensions
+This step installs python3-dev package.
+```bash
+sudo apt-get install python3-dev
+```
 
-## Step 4:  Create the virtual environment
+## Step 5:  Create the virtual environment
 This step installs all of the dependencies.  
 ```bash
 conda env create -f environment.yml
 ```
 
-## Step 5:  Activate virtual environment 
+## Step 6:  Activate virtual environment 
 Do this step every time you login. Or else put it in your `.bashrc` file.  
 ```bash
 source activate fastai


### PR DESCRIPTION
Creating virtual environment failed for me with following error:

    Complete output from command python setup.py egg_info:
    nad2bin.c:2:10: fatal error: stdio.h: No such file or directory
     #include <stdio.h>
              ^~~~~~~~~
    compilation terminated.
    using bundled proj4..
    Traceback (most recent call last):
      File "/home/tarun/anaconda3/envs/fastai/lib/python3.6/distutils/unixccompiler.py", line 118, in _compile
        extra_postargs)
      File "/home/tarun/anaconda3/envs/fastai/lib/python3.6/distutils/ccompiler.py", line 909, in spawn
        spawn(cmd, dry_run=self.dry_run)
      File "/home/tarun/anaconda3/envs/fastai/lib/python3.6/distutils/spawn.py", line 36, in spawn
        _spawn_posix(cmd, search_path, dry_run=dry_run)
      File "/home/tarun/anaconda3/envs/fastai/lib/python3.6/distutils/spawn.py", line 159, in _spawn_posix
        % (cmd, exit_status))
    distutils.errors.DistutilsExecError: command 'gcc' failed with exit status 1

In order to fix it I have to install `python3-dev` package on my newly setup ubuntu box.